### PR TITLE
ci: updated super-linter rules path

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -25,3 +25,5 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          LINTER_RULES_PATH: /

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 acr-creds.env
+super-linter.log

--- a/acr-creds-template.env
+++ b/acr-creds-template.env
@@ -1,3 +1,4 @@
+# dotenv-linter:off UnorderedKey
 #
 # Add the credentials provided to the appropriate variables below and
 # save the file as `acr-creds.env` in the directory with the scripts.


### PR DESCRIPTION
This PR tells super-linter where to find this repository's custom rules files (`./`).